### PR TITLE
Add fractional cover

### DIFF
--- a/datacube-product-definitions/ls_fractional_cover_annual.yaml
+++ b/datacube-product-definitions/ls_fractional_cover_annual.yaml
@@ -1,0 +1,215 @@
+name: ls8_fractional_cover_annual
+description: Landsat 8 Fractional Cover 30 metre
+metadata_type: eo
+
+metadata:
+    format:
+        name: GeoTIFF
+    instrument:
+        name: OLI
+    platform:
+        code: LANDSAT_8
+    product_type: fractional_cover_annual_summary
+    statistics:
+        period: 1y
+
+measurements:
+    -
+        dtype: int16
+        name: blue
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: green
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: red
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: nir
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: swir1
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: swir2
+        nodata: -9999
+        units: 'reflectance'
+
+storage:
+    driver: GeoTIFF
+    resolution:
+        y: -30
+        x: 30
+
+---
+name: ls7_fractional_cover_annual
+description: Landsat 7 Fractional Cover 30 metre
+metadata_type: eo
+
+metadata:
+    format:
+        name: GeoTIFF
+    instrument:
+        name: ETM
+    platform:
+        code: LANDSAT_7
+    product_type: fractional_cover_annual_summary
+    statistics:
+        period: 1y
+
+measurements:
+    -
+        dtype: int16
+        name: blue
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: green
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: red
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: nir
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: swir1
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: swir2
+        nodata: -9999
+        units: 'reflectance'
+
+storage:
+    driver: GeoTIFF
+    resolution:
+        y: -30
+        x: 30
+
+---
+name: ls5_fractional_cover_annual
+description: Landsat 5 Fractional Cover 30 metre
+metadata_type: eo
+
+metadata:
+    format:
+        name: GeoTIFF
+    instrument:
+        name: TM
+    platform:
+        code: LANDSAT_5
+    product_type: fractional_cover_annual_summary
+    statistics:
+        period: 1y
+
+measurements:
+    -
+        dtype: int16
+        name: blue
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: green
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: red
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: nir
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: swir1
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: swir2
+        nodata: -9999
+        units: 'reflectance'
+
+storage:
+    driver: GeoTIFF
+    resolution:
+        y: -30
+        x: 30
+
+---
+name: ls4_fractional_cover_annual
+description: Landsat 4 Fractional Cover 30 metre
+metadata_type: eo
+
+metadata:
+    format:
+        name: GeoTIFF
+    instrument:
+        name: TM
+    platform:
+        code: LANDSAT_4
+    product_type: fractional_cover_annual_summary
+    statistics:
+        period: 1y
+
+measurements:
+    -
+        dtype: int16
+        name: blue
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: green
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: red
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: nir
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: swir1
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: swir2
+        nodata: -9999
+        units: 'reflectance'
+
+storage:
+    driver: GeoTIFF
+    resolution:
+        y: -30
+        x: 30
+

--- a/datacube-product-definitions/ls_fractional_cover_annual.yaml
+++ b/datacube-product-definitions/ls_fractional_cover_annual.yaml
@@ -16,34 +16,19 @@ metadata:
 measurements:
     -
         dtype: int16
-        name: blue
+        name: bs
         nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
     -
         dtype: int16
-        name: green
+        name: npv
         nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
     -
         dtype: int16
-        name: red
+        name: pv
         nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: nir
-        nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: swir1
-        nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: swir2
-        nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
 
 storage:
     driver: GeoTIFF
@@ -70,34 +55,19 @@ metadata:
 measurements:
     -
         dtype: int16
-        name: blue
+        name: bs
         nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
     -
         dtype: int16
-        name: green
+        name: npv
         nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
     -
         dtype: int16
-        name: red
+        name: pv
         nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: nir
-        nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: swir1
-        nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: swir2
-        nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
 
 storage:
     driver: GeoTIFF
@@ -124,34 +94,19 @@ metadata:
 measurements:
     -
         dtype: int16
-        name: blue
+        name: bs
         nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
     -
         dtype: int16
-        name: green
+        name: npv
         nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
     -
         dtype: int16
-        name: red
+        name: pv
         nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: nir
-        nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: swir1
-        nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: swir2
-        nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
 
 storage:
     driver: GeoTIFF
@@ -178,34 +133,19 @@ metadata:
 measurements:
     -
         dtype: int16
-        name: blue
+        name: bs
         nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
     -
         dtype: int16
-        name: green
+        name: npv
         nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
     -
         dtype: int16
-        name: red
+        name: pv
         nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: nir
-        nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: swir1
-        nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: swir2
-        nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
 
 storage:
     driver: GeoTIFF

--- a/datacube-product-definitions/s2_fractional_cover_annual.yaml
+++ b/datacube-product-definitions/s2_fractional_cover_annual.yaml
@@ -1,0 +1,53 @@
+name: s2_fractional_cover_annual
+description: Sentinel-2 Fractional Cover 10 metre
+metadata_type: eo
+
+metadata:
+    format:
+        name: GeoTIFF
+    instrument:
+        name: MSI
+    platform:
+        code: SENTINEL_2
+    product_type: fractional_cover_annual_summary
+    statistics:
+        period: 1y
+
+measurements:
+    -
+        dtype: int16
+        name: blue
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: green
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: red
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: nir
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: swir1
+        nodata: -9999
+        units: 'reflectance'
+    -
+        dtype: int16
+        name: swir2
+        nodata: -9999
+        units: 'reflectance'
+
+storage:
+    driver: GeoTIFF
+    resolution:
+        y: -10
+        x: 10
+

--- a/datacube-product-definitions/s2_fractional_cover_annual.yaml
+++ b/datacube-product-definitions/s2_fractional_cover_annual.yaml
@@ -16,34 +16,19 @@ metadata:
 measurements:
     -
         dtype: int16
-        name: blue
+        name: bs
         nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
     -
         dtype: int16
-        name: green
+        name: npv
         nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
     -
         dtype: int16
-        name: red
+        name: pv
         nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: nir
-        nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: swir1
-        nodata: -9999
-        units: 'reflectance'
-    -
-        dtype: int16
-        name: swir2
-        nodata: -9999
-        units: 'reflectance'
+        units: 'percentage'
 
 storage:
     driver: GeoTIFF

--- a/scripts/fractional_cover.py
+++ b/scripts/fractional_cover.py
@@ -1,0 +1,86 @@
+####################
+# Fractional Cover #
+####################
+
+import xarray as xr
+from datacube_utilities.dc_fractional_coverage_classifier import frac_coverage_classify
+
+
+def process_fractional_cover(
+    dc,
+    product,
+    query_x_from,
+    query_x_to,
+    query_y_from,
+    query_y_to,
+    time_from,
+    time_to,
+    output_crs,
+    query_crs="EPSG:4326",
+    dask_time_chunk_size="10",
+    dask_x_chunk_size="600",
+    dask_y_chunk_size="600",
+    **kwargs,
+):
+    time = (time_from, time_to)
+
+    data_bands = ["red", "green", "blue", "nir", "swir1", "swir2"]
+
+    # Product here is a geomedian product
+    if product.startswith("ls"):
+        resolution = (-30, 30)
+        nodata = -9999
+        water_product = product[:3] + "_water_classification"
+    else:
+        resolution = (-10, 10)
+        nodata = 0
+        # TODO: Change when S2 WOFS ready
+        water_product = None
+        return None
+
+    query = {}
+
+    query["output_crs"] = output_crs
+    query["resolution"] = resolution
+    query["dask_chunks"] = {
+        "time": int(dask_time_chunk_size),
+        "x": int(dask_x_chunk_size),
+        "y": int(dask_y_chunk_size),
+    }
+
+    if query_crs != "EPSG:4326":
+        query["crs"] = query_crs
+
+    query["x"] = (float(query_x_from), float(query_x_to))
+    query["y"] = (float(query_y_from), float(query_y_to))
+
+    water_scenes = dc.load(
+        product=water_product, measurements=["water_classification"], time=time, **query
+    )
+    water_scenes = water_scenes.where(water_scenes >= 0)
+
+    water_composite_mean = water_scenes.water_classification.mean(dim="time")
+
+    land_composite = dc.load(
+        product=product, measurements=data_bands, time=time, **query
+    )
+
+    if len(land_composite.dims) == 0 or len(land_composite.data_vars) == 0:
+        return None
+
+    # Fractional Cover Classification
+
+    frac_classes = xr.map_blocks(
+        frac_coverage_classify, land_composite, kwargs={"no_data": nodata}
+    )
+
+    # Mask to remove clounds, cloud shadow, and water.
+    frac_cov_masked = frac_classes.where(
+        (frac_classes != nodata) & (water_composite_mean <= 0.4)
+    )
+
+    ## Compute
+
+    fractional_cover = frac_cov_masked.compute()
+
+    return fractional_cover

--- a/scripts/fractional_cover.py
+++ b/scripts/fractional_cover.py
@@ -22,6 +22,7 @@ def process_fractional_cover(
     dask_y_chunk_size="600",
     **kwargs,
 ):
+    nodata = -9999
     time = (time_from, time_to)
 
     data_bands = ["red", "green", "blue", "nir", "swir1", "swir2"]
@@ -29,11 +30,9 @@ def process_fractional_cover(
     # Product here is a geomedian product
     if product.startswith("ls"):
         resolution = (-30, 30)
-        nodata = -9999
         water_product = product[:3] + "_water_classification"
     else:
         resolution = (-10, 10)
-        nodata = 0
         # TODO: Change when S2 WOFS ready
         water_product = None
         return None

--- a/scripts/geomedian.py
+++ b/scripts/geomedian.py
@@ -2,64 +2,64 @@
 # Geometric median #
 ####################
 
-import numpy as np
-import xarray as xr
-
-import hdstats
 import odc.algo
 from odc.algo import to_f32, from_float, xr_geomedian
 from masking import mask_good_quality
 
-from pyproj import Proj, transform
 
-def process_geomedian(dc,
-                      product,
-                      query_x_from, query_x_to,
-                      query_y_from, query_y_to,
-                      time_from, time_to,
-                      output_crs,
-                      query_crs='EPSG:4326',
-                      dask_chunk_size='1000',
-                      **kwargs):
+def process_geomedian(
+    dc,
+    product,
+    query_x_from,
+    query_x_to,
+    query_y_from,
+    query_y_to,
+    time_from,
+    time_to,
+    output_crs,
+    query_crs="EPSG:4326",
+    dask_chunk_size="1000",
+    **kwargs,
+):
     time_extents = (time_from, time_to)
 
-    data_bands = ['red', 'green', 'blue', 'nir', 'swir1', 'swir2']
-    mask_bands = ['pixel_qa' if product.startswith('ls') else 'scene_classification']
+    data_bands = ["red", "green", "blue", "nir", "swir1", "swir2"]
+    mask_bands = ["pixel_qa" if product.startswith("ls") else "scene_classification"]
 
-    if product.startswith('ls'):
+    if product.startswith("ls"):
         resolution = (-30, 30)
-        group_by='solar_day'
+        group_by = "solar_day"
         nodata = -9999
     else:
         resolution = (-10, 10)
-        group_by='time'
+        group_by = "time"
         nodata = 0
 
     query = {}
 
-    query['product'] = product
-    query['time'] = time_extents
-    query['output_crs'] = output_crs
-    query['resolution'] = resolution
-    query['measurements'] = data_bands + mask_bands
-    query['group_by'] = group_by
-    query['dask_chunks'] = {
-      'x': int(dask_chunk_size),
-      'y': int(dask_chunk_size)
-    }
+    query["product"] = product
+    query["time"] = time_extents
+    query["output_crs"] = output_crs
+    query["resolution"] = resolution
+    query["measurements"] = data_bands + mask_bands
+    query["group_by"] = group_by
+    query["dask_chunks"] = {"x": int(dask_chunk_size), "y": int(dask_chunk_size)}
 
-    if query_crs != 'EPSG:4326':
-        query['crs'] = query_crs
+    if query_crs != "EPSG:4326":
+        query["crs"] = query_crs
 
-    query['x'] = (float(query_x_from), float(query_x_to))
-    query['y'] = (float(query_y_from), float(query_y_to))
+    query["x"] = (float(query_x_from), float(query_x_to))
+    query["y"] = (float(query_y_from), float(query_y_to))
 
-    xx = dc.load(**query) # use the query we defined above
+    xx = dc.load(**query)  # use the query we defined above
 
     if len(xx.dims) == 0 or len(xx.data_vars) == 0:
         return None
 
-    scale, offset = (1/10_000, 0)  # differs per product, aim for 0-1 values in float32
+    scale, offset = (
+        1 / 10_000,
+        0,
+    )  # differs per product, aim for 0-1 values in float32
 
     # Identify pixels with valid data (requires working with native resolution datasets)
     good_quality = mask_good_quality(xx, product)
@@ -67,17 +67,16 @@ def process_geomedian(dc,
     xx_data = xx[data_bands]
     xx_clean = odc.algo.keep_good_only(xx_data, where=good_quality)
     xx_clean = to_f32(xx_clean, scale=scale, offset=offset)
-    yy = xr_geomedian(xx_clean,
-                      num_threads=1,  # disable internal threading, dask will run several concurrently
-                      eps=0.2*scale,  # 1/5 pixel value resolution
-                      nocheck=True)   # disable some checks inside geomedian library that use too much ram
-    yy = from_float(yy,
-                    dtype='int16',
-                    nodata=nodata,
-                    scale=1/scale,
-                    offset=-offset/scale)
+    yy = xr_geomedian(
+        xx_clean,
+        num_threads=1,  # disable internal threading, dask will run several concurrently
+        eps=0.2 * scale,  # 1/5 pixel value resolution
+        nocheck=True,
+    )  # disable some checks inside geomedian library that use too much ram
+    yy = from_float(
+        yy, dtype="int16", nodata=nodata, scale=1 / scale, offset=-offset / scale
+    )
 
     yy = yy.compute()
 
     return yy
-

--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -20,6 +20,12 @@ def process_request(dc, s3_client, job_code, **kwargs):
             ds = process_geomedian(dc=dc, **kwargs)
             save_bands = ['red', 'green', 'blue', 'nir', 'swir1', 'swir2']
 
+        if job_code == "fractional_cover":
+            from fractional_cover import process_fractional_cover
+
+            ds = process_fractional_cover(dc=dc, **kwargs)
+            save_bands = ['bs', 'pv', 'npv']
+
         if ds:
             logging.info("Saving data.")
             save_data(s3_client=s3_client, ds=ds, job_code=job_code, bands=save_bands, **kwargs)


### PR DESCRIPTION
Notes:
* `product` here is the geomedian annual summary product
* The way dask chunk size is defined for geomedian isn't granular enough for fractional cover - we want to be able to set a size for the `time` chunk as well as x and y.
* I've accidentally formatted the geomedian script with Black. Let me know if you don't like this and I'll undo.
* This script is quite different to the on-demand fractional cover generation script. I think it makes sense not to try to combine the two.

Things I'm not sure about:
* For Sentinal 2, the product definition for geomedian gives nodata=-9999 but the geomedian script gives nodata=0. The fractional cover definition/script copies this. Is this correct?
* Should I be adding some job examples?
* Not 100% certain about the product definitions I've added but Sarah has volunteered to check